### PR TITLE
Implement Node IPAM Controller

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -8,4 +8,9 @@ layout:
 projectName: metal-load-balancer-controller
 repo: github.com/ironcore-dev/metal-load-balancer-controller
 resources:
+- controller: true
+  group: core
+  kind: Node
+  path: k8s.io/api/core/v1
+  version: v1
 version: "3"

--- a/cmd/metal-load-balancer-controller/main.go
+++ b/cmd/metal-load-balancer-controller/main.go
@@ -42,12 +42,17 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var nodeCIDRMaskSize int
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var allocateNodeCIDR bool
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.IntVar(&nodeCIDRMaskSize, "node-cidr-mask-size", 80, "Specifies the pod cidr mask size to be allocated to nodes.")
+	flag.BoolVar(&allocateNodeCIDR, "allocate-node-cidr", false,
+		"If set, PodCIDRs will be allocated to the Node.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -136,6 +141,17 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		os.Exit(1)
+	}
+
+	if allocateNodeCIDR {
+		if err = (&metalloadbalancercontroller.NodeIPAMReconciler{
+			Client:           mgr.GetClient(),
+			Scheme:           mgr.GetScheme(),
+			NodeCIDRMaskSize: nodeCIDRMaskSize,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "NodeIPAM")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,3 +24,21 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/internal/metal-load-balancer-controller/node_ipam_controller.go
+++ b/internal/metal-load-balancer-controller/node_ipam_controller.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metal_load_balancer_controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NodeIPAMReconciler reconciles a Node object
+type NodeIPAMReconciler struct {
+	client.Client
+	Scheme           *runtime.Scheme
+	NodeCIDRMaskSize int
+}
+
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;update;patch
+
+func (r *NodeIPAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	node := &corev1.Node{}
+	if err := r.Get(ctx, req.NamespacedName, node); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if node.Spec.PodCIDR != "" {
+		logger.Info("PodCIDR is already populated; patch was not done", "NodeIPAM", node.Name, "PodCIDR", node.Spec.PodCIDR)
+		return ctrl.Result{}, nil
+	}
+
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			podCIDR := fmt.Sprintf("%s/%d", addr.Address, r.NodeCIDRMaskSize)
+
+			nodeBase := node.DeepCopy()
+			node.Spec.PodCIDR = podCIDR
+			if node.Spec.PodCIDRs == nil {
+				node.Spec.PodCIDRs = []string{}
+			}
+			node.Spec.PodCIDRs = append(node.Spec.PodCIDRs, podCIDR)
+
+			if err := r.Patch(ctx, node, client.MergeFrom(nodeBase)); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to patch Node's PodCIDR with error %w", err)
+			}
+
+			logger.Info("Patched Node's PodCIDR and PodCIDRs", "NodeIPAM", node.Name, "PodCIDR", podCIDR)
+			break
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NodeIPAMReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Complete(r)
+}

--- a/internal/metal-load-balancer-controller/node_ipam_controller_test.go
+++ b/internal/metal-load-balancer-controller/node_ipam_controller_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metal_load_balancer_controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("Node IPAM Controller", func() {
+	Context("When the PodCIDR is not populated", func() {
+		It("should populate PodCIDR and PodCIDRs", func(ctx SpecContext) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Spec: corev1.NodeSpec{
+					PodCIDR:  "",
+					PodCIDRs: []string{},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "1a10:c0de::1",
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+			DeferCleanup(k8sClient.Delete, node)
+
+			Eventually(Object(node)).Should(SatisfyAll(
+				HaveField("Spec.PodCIDR", Equal("1a10:c0de::1/64")),
+				HaveField("Spec.PodCIDRs", ContainElement("1a10:c0de::1/64")),
+			))
+
+		})
+	})
+
+	Context("When the PodCIDR is already populated", func() {
+		It("should not modify PodCIDR and PodCIDRs", func(ctx SpecContext) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-",
+				},
+				Spec: corev1.NodeSpec{
+					PodCIDR: "cafe:c0de::/80",
+					PodCIDRs: []string{
+						"cafe:c0de::/80",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "1a10:code::1",
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+			DeferCleanup(k8sClient.Delete, node)
+
+			Eventually(Object(node)).Should(SatisfyAll(
+				HaveField("Spec.PodCIDR", Equal("cafe:c0de::/80")),
+				HaveField("Spec.PodCIDRs", ContainElement("cafe:c0de::/80")),
+			))
+		})
+	})
+})

--- a/internal/metal-load-balancer-controller/suite_test.go
+++ b/internal/metal-load-balancer-controller/suite_test.go
@@ -95,6 +95,12 @@ var _ = BeforeSuite(func() {
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)).To(Succeed())
 
+	Expect((&NodeIPAMReconciler{
+		Client:           k8sManager.GetClient(),
+		Scheme:           k8sManager.GetScheme(),
+		NodeCIDRMaskSize: 64,
+	}).SetupWithManager(k8sManager)).To(Succeed())
+
 	go func() {
 		defer GinkgoRecover()
 		Expect(k8sManager.Start(mgrCtx)).To(Succeed(), "failed to start manager")


### PR DESCRIPTION
# Proposed Changes

This PR is introducing a controller that dynamically updates Node objects' PodCIDRs based on their NodeIPs. The motivation is to ensure Pod networking is optimally configured to reflect Node-specific IP ranges.

Fixes #